### PR TITLE
Rename the dismiss() to dismissWithAnimation()

### DIFF
--- a/library/src/main/java/cn/pedant/SweetAlert/SweetAlertDialog.java
+++ b/library/src/main/java/cn/pedant/SweetAlert/SweetAlertDialog.java
@@ -305,7 +305,10 @@ public class SweetAlertDialog extends Dialog implements View.OnClickListener {
         playAnimation();
     }
 
-    public void dismiss() {
+    /**
+     * The real Dialog.dismiss() will be invoked async-ly after the animation finishes.
+     */
+    public void dismissWithAnimation() {
         mConfirmButton.startAnimation(mOverlayOutAnim);
         mDialogView.startAnimation(mModalOutAnim);
     }
@@ -316,13 +319,13 @@ public class SweetAlertDialog extends Dialog implements View.OnClickListener {
             if (mCancelClickListener != null) {
                 mCancelClickListener.onClick(SweetAlertDialog.this);
             } else {
-                dismiss();
+                dismissWithAnimation();
             }
         } else if (v.getId() == R.id.confirm_button) {
             if (mConfirmClickListener != null) {
                 mConfirmClickListener.onClick(SweetAlertDialog.this);
             } else {
-                dismiss();
+                dismissWithAnimation();
             }
         }
     }


### PR DESCRIPTION
So that we can still use the default super.dismiss() to sync-ly dismiss the dialog, which can prevent us from window leak #9 
